### PR TITLE
Fixing an error with a type not being public

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.2.0"
+          otp-version: "27.1.2"
+          gleam-version: "1.9.1"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.1/.schema/devbox.schema.json",
+  "packages": [
+    "gleam@1",
+    "erlang@27.2",
+    "rebar3@latest"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,153 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "erlang@27.2": {
+      "last_modified": "2024-12-26T01:25:00Z",
+      "resolved": "github:NixOS/nixpkgs/16e046229f3b4f53257973a5532bcbb72457d2f2#erlang",
+      "source": "devbox-search",
+      "version": "27.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6lg2nrxxd79s2k1ij4hsvfgiwhbisy5v-erlang-27.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6lg2nrxxd79s2k1ij4hsvfgiwhbisy5v-erlang-27.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/swym0vp55ayg9yv2zp18dzybq66y267l-erlang-27.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/swym0vp55ayg9yv2zp18dzybq66y267l-erlang-27.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rlmwsbfv7pbxps28ap0hryf8yk3swiw4-erlang-27.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/rlmwsbfv7pbxps28ap0hryf8yk3swiw4-erlang-27.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/186j3w6wqlqqc8c2sljxhw72ffvc5h0p-erlang-27.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/186j3w6wqlqqc8c2sljxhw72ffvc5h0p-erlang-27.2"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-04-13T09:22:33Z",
+      "resolved": "github:NixOS/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11?lastModified=1744536153&narHash=sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg%2FN38%3D"
+    },
+    "gleam@1": {
+      "last_modified": "2025-04-07T13:23:10Z",
+      "resolved": "github:NixOS/nixpkgs/b0b4b5f8f621bfe213b8b21694bab52ecfcbf30b#gleam",
+      "source": "devbox-search",
+      "version": "1.9.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qz6273bjy0l0252asrzlfbq9gzgimam7-gleam-1.9.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/qz6273bjy0l0252asrzlfbq9gzgimam7-gleam-1.9.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jjz1gs4ryybqcb617pn56ccq029i3yd1-gleam-1.9.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/jjz1gs4ryybqcb617pn56ccq029i3yd1-gleam-1.9.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lk022maix6xak0jrkfp4jk6v1mvv8avn-gleam-1.9.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lk022maix6xak0jrkfp4jk6v1mvv8avn-gleam-1.9.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yg8chrcasxcrff1v38a0xhk0s6y921vs-gleam-1.9.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/yg8chrcasxcrff1v38a0xhk0s6y921vs-gleam-1.9.1"
+        }
+      }
+    },
+    "rebar3@latest": {
+      "last_modified": "2024-12-26T01:25:00Z",
+      "resolved": "github:NixOS/nixpkgs/16e046229f3b4f53257973a5532bcbb72457d2f2#rebar3",
+      "source": "devbox-search",
+      "version": "3.24.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/j8x4awhnv0jnbg5y3b7i61jphgl5ikp8-rebar3-3.24.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/j8x4awhnv0jnbg5y3b7i61jphgl5ikp8-rebar3-3.24.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/iaj9f0501klpszxyzpzabfyf0lir3b3v-rebar3-3.24.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/iaj9f0501klpszxyzpzabfyf0lir3b3v-rebar3-3.24.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xyha83p1q95zkwzflqf9iy5p7fi8539y-rebar3-3.24.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/xyha83p1q95zkwzflqf9iy5p7fi8539y-rebar3-3.24.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/0320iwslqglskr2jmak6x5wq6sssybqa-rebar3-3.24.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/0320iwslqglskr2jmak6x5wq6sssybqa-rebar3-3.24.0"
+        }
+      }
+    }
+  }
+}

--- a/gleam.toml
+++ b/gleam.toml
@@ -15,7 +15,7 @@ licences = ["MIT"]
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 file_streams = ">= 0.6.1 and < 1.0.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,11 +3,11 @@
 
 packages = [
   { name = "file_streams", version = "0.6.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "file_streams", source = "hex", outer_checksum = "EC0DA36A4A5A79EB1281DD21247F062AD64D171D53C06ED4B4F520B0BC77F710" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_stdlib", version = "0.59.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F8FEE9B35797301994B81AF75508CF87C328FE1585558B0FFD188DC2B32EAA95" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
 file_streams = { version = ">= 0.6.1 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/glexif/exif_tag.gleam
+++ b/src/glexif/exif_tag.gleam
@@ -1,4 +1,4 @@
-import gleam/option.{type Option, None, Some}
+import gleam/option.{type Option, None}
 import glexif/exif_tags/color_space.{type ColorSpace}
 import glexif/exif_tags/components_configuration.{type ComponentsConfiguration}
 import glexif/exif_tags/composite_image.{type CompositeImage}

--- a/src/glexif/internal/raw.gleam
+++ b/src/glexif/internal/raw.gleam
@@ -3,7 +3,6 @@ import file_streams/file_stream_error
 import gleam/bit_array
 import gleam/dict
 import gleam/int
-import gleam/io
 import gleam/list
 import gleam/option.{Some}
 import gleam/result
@@ -312,7 +311,7 @@ pub fn get_raw_entries(
       tiff_header,
     ))
     // need to reverse it one more time to get back the right order since
-    // the parse_data_or_offset also had to do its own reverse. 
+    // the parse_data_or_offset also had to do its own reverse.
     // Definitely should be a better way to do this, but it looks to work
     |> try_reverse_if_intel(tiff_header)
 
@@ -1002,8 +1001,8 @@ pub fn raw_exif_entry_to_parsed_tag(
       exif_tag.ExifTagRecord(..record, gps_speed: Some(gps_speed))
     }
 
-    u -> {
-      // io.debug(u)
+    _u -> {
+      // io.debug(_u)
       record
     }
   }
@@ -1123,7 +1122,7 @@ fn extract_signed_rational_to_fraction(data: BitArray) -> Fraction {
     _ -> panic as "wut?"
   }
 
-  // TODO: For now just treat as unsigned rational since my 
+  // TODO: For now just treat as unsigned rational since my
   // test data has this as positive values
   let numerator =
     data
@@ -1139,7 +1138,7 @@ fn extract_signed_rational_to_fraction(data: BitArray) -> Fraction {
   Fraction(numerator, denominator)
 }
 
-type OffsetLocation {
+pub type OffsetLocation {
   IFD
   // regular
   GPS

--- a/src/glexif/internal/utils.gleam
+++ b/src/glexif/internal/utils.gleam
@@ -1,10 +1,9 @@
 import gleam/bit_array
 import gleam/int
-import gleam/io
 import gleam/result
 
 pub fn print_bit_array(arr: Result(BitArray, Nil)) -> Nil {
-  io.debug(bit_array.inspect(result.unwrap(arr, <<>>)))
+  echo bit_array.inspect(result.unwrap(arr, <<>>))
   Nil
 }
 

--- a/test/glexif_test.gleam
+++ b/test/glexif_test.gleam
@@ -1,4 +1,3 @@
-import gleam/io
 import gleam/option.{None, Some}
 import gleeunit
 import gleeunit/should


### PR DESCRIPTION
Thanks so much for making glexif.

I tried to use glexif with a brand new Gleam project and it didn't work out of the box. I have not done a deep dive on this project though, so sorry if these changes are naïve (I'm also very new to Gleam as a language and an ecosystem).

I think the only error I fixed was that the `OffsetLocation` type needed to be public since it was part of the signature of a public function.

The other changes are fixes for warnings.

The one thing that's in here, that you _might_ not want is the `devbox` configuration files (I've been using [devbox](https://www.jetify.com/devbox) for more and more stuff). You might not want them in _your_ code base (I can take them out of the PR if you want). But even if you don't want them, it might be interesting to see what the environment was I was working in.

All that to say, with these changes, the library now is working for me. I'm just bring it, into my project as a local decency.

Thanks again